### PR TITLE
[intel/portage] Remove mask on dev-games/cegui, not relevant anymore. Al...

### DIFF
--- a/conf/intel/portage/package.mask/00-sabayon.package.mask
+++ b/conf/intel/portage/package.mask/00-sabayon.package.mask
@@ -132,9 +132,6 @@ media-sound/paprefs
 # 2011-08-17 Fabio Erculiani: Conflicts with x11-terms/terminal
 gnustep-apps/terminal
 
-# 2011-11-02 Joost Ruis: Breaks games-arcade/smc. See Gentoo bug #357761 
->dev-games/cegui-0.6.2b 
-
 # Fabio Erculiani, matter masks (preserved-libs bullshit):
 # updated by S. Nizio
 >app-i18n/fcitx-4.2.7


### PR DESCRIPTION
Remove mask on dev-games/cegui, not relevant anymore. Also see bug #2615
