### PR TITLE
[intel/portage] Enable use cg and ois flags on dev-games/ogre, needed to...

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -106,6 +106,7 @@ dev-embedded/openocd ftdi
 
 dev-games/cegui devil
 dev-games/crystalspace mng
+dev-games/ogre cg ois
 
 dev-java/antlr cxx
 dev-java/bsh bsf


### PR DESCRIPTION
[intel/portage] Enable use cg and ois flags on dev-games/ogre, needed to complete bug #4209
