### PR TITLE
[intel/portage] Enable mtp use flag on media-sound/clementine, this was ...

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -416,6 +416,7 @@ net-misc/nxclient prebuilt
 net-misc/nxnode prebuilt vnc
 net-misc/openssh -X
 net-misc/openssh -ldap
+net-misc/ps3mediaserver multiuser tsmuxer
 net-misc/tightvnc -java server
 net-misc/tor threads
 net-misc/vinagre -avahi


### PR DESCRIPTION
Enable mtp use flag on media-sound/clementine, this was requested in bug #4279
