### PR TITLE
[intel/portage] add USE=wma for media-sound/deadbeef

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -487,7 +487,7 @@ media-sound/banshee podcast -ipod -zeroconf mtp njb
 media-sound/cantata replaygain taglib cdparanoia
 media-sound/clementine lastfm ios moodbar mtp
 media-sound/cmus mikmod
-media-sound/deadbeef alac ape cover curl lastfm m3u hotkeys sndfile supereq wavpack
+media-sound/deadbeef alac ape cover curl lastfm m3u hotkeys sndfile supereq wavpack wma
 media-sound/gmusicbrowser gstreamer
 media-sound/gpodder gstreamer
 media-sound/jack-audio-connection-kit -mmx -cpudetection -ffado


### PR DESCRIPTION
Without USE=wma DeaDBeeF can't open and play Windows Media Audio files.