### PR TITLE
[intel/portage] masking newer vbox components versions until they work

### DIFF
--- a/conf/intel/portage/package.mask/00-sabayon.package.mask
+++ b/conf/intel/portage/package.mask/00-sabayon.package.mask
@@ -228,6 +228,15 @@ net-p2p/bittornado::gentoo
 # 2015-04-29 Joost Ruis: Breaks app-arch/zpipe, see Gentoo bug #535990
 >=app-arch/libzpaq-7.04
 
+# 2015-05-21 Ettore Di Giacinto: Holding vbox and vbox components to a stable version until it's stable
+>app-emulation/virtualbox-4.3.18
+>app-emulation/virtualbox-guest-additions-4.3.18
+>app-emulation/virtualbox-modules-4.3.18
+>x11-drivers/xf86-video-virtualbox-4.3.18
+>app-emulation/virtualbox-extpack-oracle-4.3.18
+>app-emulation/virtualbox-bin-4.3.18
+>app-emulation/virtualbox-additions-4.3.18
+
 # Temp mask
 =virtual/perl-DB_File-1.831.0
 >virtual/perl-File-Spec-3.480.0


### PR DESCRIPTION
[intel/portage] masking newer vbox components versions until they work properly, downgrading to stable