### PR TITLE
Updating gnome-base/gnome-control-center use flags

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -1087,6 +1087,9 @@ app-cdr/brasero tracker
 # required by gnome-base/gnome (argument)
 gnome-base/nautilus tracker
 
+## GNOME 3.16 flags
+>=gnome-base/gnome-control-center-3.16.2 kerberos networkmanager v4l
+
 # VAAPI/VDPAU support
 media-libs/avidemux-core vaapi vdpau
 media-libs/xine-lib vaapi vdpau


### PR DESCRIPTION
Since 3.16.2, gnome-control-center needs the networkmanager use flag to enable the network section in the control center.