### PR TITLE
Enable app-emulation/vmware-workstation USE="ovftool server vix"

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -76,6 +76,7 @@ app-emulation/libvirt lxc rbd virtualbox fuse kvm qemu virt-network lvm caps isc
 app-emulation/qemu glusterfs nfs rbd fdt spice -gtk virtfs xattr usbredir gtk virgl
 app-emulation/vice -gtk
 app-emulation/virtualbox-bin additions vboxwebsrv -chm rdesktop-vrdp
+app-emulation/vmware-workstation ovftool server vix
 # Wine, more features
 app-emulation/wine fontconfig pipelight samba staging udisks
 app-emulation/winetricks -gtk


### PR DESCRIPTION
ovftool and vix are required for Sabayon VMware OVA images to be built
automatically. Enabling server to allow VMs to be run unattended if
needed.

For instructions to build Sabayon images using packer, see
https://wiki.sabayon.org/index.php?title=HOWTO:_Building_Sabayon_images_using_Packer