### PR TITLE
Compile in NetworkManager cross-compatibility for connman

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -1062,9 +1062,10 @@ dev-python/pylons genshi jinja
 
 # openresolv support
 net-dns/bind dlz resolvconf
-net-misc/connman resolvconf
 net-misc/networkmanager resolvconf
 net-vpn/vpnc resolvconf
+# networkmanager cross-compatibility for connman
+net-misc/connman resolvconf networkmanager
 
 sys-auth/polkit -kde -gtk
 media-libs/libpng apng


### PR DESCRIPTION
Programs like Chrome, Firefox etc. all support getting the users connection
status using the NetworkManager API for checking this information.

Connman with built with the --enable-nmcompat enables this functionality.
NetworkManager is the most widely used API that things such as web browsers
and many other programs can easily determine a computers connection status.

Use the networkmanager USE flag so we can get this functionality.