### PR TITLE
intel/package.use: www-client/uget add aria2 use flag

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -931,7 +931,7 @@ www-client/firefox filepicker -gnome gstreamer mozbranding system-jpeg xforms
 www-client/midori sqlite
 www-client/qupzilla -qt4
 www-client/surf savedconfig
-www-client/uget gstreamer
+www-client/uget gstreamer aria2
 
 # 32bit plugin is unwanted
 www-plugins/adobe-flash -32bit sse2


### PR DESCRIPTION
aria2 allows use of aria as downloading backend if aria2
is installed. This use flag does not add any additional dependencies.