### PR TITLE
intel/package.use: dev-java/oracle-jre-bin add jce USE flag

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -1277,7 +1277,7 @@ net-p2p/bitcoin-qt -qt4 ljr
 dev-java/oracle-jdk-bin javafx -nsplugin
 
 # -nsplugin: conflicts with dev-java/icedtea-web[nsplugin]
-dev-java/oracle-jre-bin -nsplugin
+dev-java/oracle-jre-bin -nsplugin jce
 app-emulation/runc apparmor
 
 # Require mkfs.dosfs


### PR DESCRIPTION
jce allows the use of stronger encryption such as newer TLS
and AES encryption.