### PR TITLE
intel/package.use: app-backup/bacula database backends

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -28,7 +28,7 @@ app-arch/unzip natspec
 
 # Disable KDE on backintime
 app-backup/backintime gnome -kde
-app-backup/bacula sqlite3
+app-backup/bacula mysql postgresql sqlite3 vim-syntax
 app-backup/deja-dup nautilus
 app-backup/fsarchiver lzma
 


### PR DESCRIPTION
Enable database backends and vim-syntax on app-backup/bacula.
Sqlite is only intended for proof-of-concept and a proper database is required for production usage of bacula.