### PR TITLE
intel/package.use: x11-libs/libva Add 'utils' USE flag

### DIFF
--- a/conf/intel/portage/package.use/00-sabayon.package.use
+++ b/conf/intel/portage/package.use/00-sabayon.package.use
@@ -978,7 +978,7 @@ x11-libs/cairo glitz -qt4
 x11-libs/goffice gnome
 x11-libs/libdrm video_cards_amdgpu video_cards_intel video_cards_nouveau video_cards_radeon video_cards_vmware libkms
 # libva coolness
-x11-libs/libva video_cards_dummy video_cards_intel
+x11-libs/libva video_cards_dummy video_cards_intel utils
 
 # keep them in sync
 x11-libs/qscintilla qt4 qt5


### PR DESCRIPTION
Add the utils USE flag so the `vainfo` utility is installed.